### PR TITLE
OAuth / 전역 상태 / 라우트 가드 구현

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -23,6 +23,7 @@
         "react-redux": "^8.1.3",
         "react-router-dom": "^6.18.0",
         "react-scripts": "5.0.1",
+        "redux-persist": "^6.0.0",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
       },
@@ -14760,6 +14761,14 @@
       "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "dependencies": {
         "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "peerDependencies": {
+        "redux": ">4.0.0"
       }
     },
     "node_modules/redux-thunk": {

--- a/front/package.json
+++ b/front/package.json
@@ -18,6 +18,7 @@
     "react-redux": "^8.1.3",
     "react-router-dom": "^6.18.0",
     "react-scripts": "5.0.1",
+    "redux-persist": "^6.0.0",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
   },

--- a/front/src/components/Navigation/NavList.tsx
+++ b/front/src/components/Navigation/NavList.tsx
@@ -2,12 +2,16 @@ import { NavLink } from 'react-router-dom';
 
 import styles from '../../styles/Navigation.module.css';
 import logo from '../../assets/42logo.svg';
+import { RootStoreType } from '../../store';
+import { useSelector } from 'react-redux';
 
 const checkNavActivation = ({ isActive }: { isActive: boolean }): string => {
   return isActive ? styles.active : '';
 };
 
 const NavList = () => {
+  const auth = useSelector((state: RootStoreType) => state.auth);
+
   return (
     <ul className={styles.nav_list}>
       <div className={styles.logo}>
@@ -16,7 +20,10 @@ const NavList = () => {
         </NavLink>
       </div>
       <li>
-        <NavLink to="/dashboard" className={checkNavActivation}>
+        <NavLink
+          to={`/dashboard/${auth.userID}`}
+          className={checkNavActivation}
+        >
           전적
         </NavLink>
       </li>

--- a/front/src/components/Navigation/UserDropdown.tsx
+++ b/front/src/components/Navigation/UserDropdown.tsx
@@ -1,16 +1,22 @@
-import { useNavigate, useSubmit } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import styles from '../../styles/Dropdown.module.css';
+import { RootStoreType } from '../../store';
+import { useDispatch, useSelector } from 'react-redux';
+import { actions as authActions } from '../../store/auth';
 
 const UserDropdown = () => {
-  const submit = useSubmit();
+  const auth = useSelector((state: RootStoreType) => state.auth);
+  const dispatch = useDispatch();
+
   const navigate = useNavigate();
 
   const navigateHandler = () => {
-    navigate('/profile');
+    navigate(`/profile/${auth.userID}`);
   };
 
   const logoutHandler = () => {
-    submit(null, { action: '/logout', method: 'POST' });
+    dispatch(authActions.logout());
+    navigate('/login');
   };
 
   return (

--- a/front/src/routes/Game.tsx
+++ b/front/src/routes/Game.tsx
@@ -3,53 +3,69 @@ import useCanvasSize from '../components/WebGL/hook/useCanvasSize';
 import gameLoop from '../components/WebGL/function/gameLoop';
 import shader from '../components/WebGL/function/shader';
 import initialize from '../components/WebGL/function/initialize';
-import usePress from "../components/WebGL/hook/usePress";
+import usePress from '../components/WebGL/hook/usePress';
 import useCloseModal from '../components/Modal/useCloseModal';
 
 const GamePage = () => {
-    const closeModal = useCloseModal();
-  
-    const canvasRef = useRef<HTMLCanvasElement>(null);
-    const [error, setError] = useState(null);
-    useCanvasSize(canvasRef);
-    usePress();
-    
-    useEffect(() => {
-      closeModal();
-        try {
-            /* webGL 초기화 */
-            initialize(canvasRef);
-            /* shader 세팅 */
-            shader();
+  const closeModal = useCloseModal();
 
-            /* 렌더링 */
-            requestAnimationFrame(gameLoop);
-            // render();
-        } catch (e : any) {
-            setError(e.message);
-        }
-    }, []);
-    if (error) {
-        return (
-            <div style={{color:'#be0000', display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh', flexDirection: 'column'}}>
-                <h1 className="error-message" >Error</h1>
-                <p>{error}</p>
-            </div>
-        );
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [error, setError] = useState(null);
+  useCanvasSize(canvasRef);
+  usePress();
+
+  useEffect(() => {
+    closeModal();
+    try {
+      /* webGL 초기화 */
+      initialize(canvasRef);
+      /* shader 세팅 */
+      shader();
+
+      /* 렌더링 */
+      requestAnimationFrame(gameLoop);
+      // render();
+    } catch (e: any) {
+      setError(e.message);
     }
-
+  }, [closeModal]);
+  if (error) {
     return (
-        <main>
-            <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>
-                <canvas
-                    ref={canvasRef}
-                    width="600"
-                    height={window.innerHeight}
-                    style={{ backgroundColor: 'black', boxShadow: '0 4px 15px red' }}
-                ></canvas>
-            </div>
-        </main>
+      <div
+        style={{
+          color: '#be0000',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: '100vh',
+          flexDirection: 'column',
+        }}
+      >
+        <h1 className="error-message">Error</h1>
+        <p>{error}</p>
+      </div>
     );
+  }
+
+  return (
+    <main>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: '100vh',
+        }}
+      >
+        <canvas
+          ref={canvasRef}
+          width="600"
+          height={window.innerHeight}
+          style={{ backgroundColor: 'black', boxShadow: '0 4px 15px red' }}
+        ></canvas>
+      </div>
+    </main>
+  );
 };
 
 export default GamePage;

--- a/front/src/routes/Login.tsx
+++ b/front/src/routes/Login.tsx
@@ -1,12 +1,11 @@
-import { useNavigate } from 'react-router-dom';
-
 import styles from '../styles/Login.module.css';
 import ftLogo from '../assets/42logo.svg';
 
 const LoginPage = () => {
-  const navigate = useNavigate();
-  const clickHandler = () => {
-    navigate('/two-factor-auth');
+  const clickHandler = async () => {
+    const res = await fetch('http://localhost:3000/login');
+    const data = await res.json();
+    console.log(data);
   };
 
   return (

--- a/front/src/routes/Login.tsx
+++ b/front/src/routes/Login.tsx
@@ -1,10 +1,11 @@
 import styles from '../styles/Login.module.css';
 import ftLogo from '../assets/42logo.svg';
-import { Link, LoaderFunctionArgs, json, redirect } from 'react-router-dom';
+import { Link } from 'react-router-dom';
+
+const redirectURL =
+  'https://api.intra.42.fr/oauth/authorize?client_id=u-s4t2ud-6d75e45537dfe63cb877db3a4a1fdc80d44a07866b83d40b693a2c147c0787da&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth&response_type=code';
 
 const LoginPage = () => {
-  const redirectURL = process.env.REACT_APP_REDIRECT_URL;
-
   return (
     <div className={styles.login}>
       <img src={ftLogo} alt="42 icon" />
@@ -16,27 +17,5 @@ const LoginPage = () => {
     </div>
   );
 };
+
 export default LoginPage;
-
-export const getTokenLoader = async ({ request }: LoaderFunctionArgs) => {
-  const url = new URL(request.url);
-  const authCode = url.searchParams.get('code');
-
-  const res = await fetch('http://localhost:3001/api/auth', {
-    method: 'POST',
-    body: JSON.stringify({ code: authCode }),
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  });
-
-  if (!res.ok) {
-    throw json({ message: '로그인에 실패하였습니다' }, { status: 500 });
-  }
-
-  const data = await res.json();
-
-  console.log(data);
-  // 분기
-  return null;
-};

--- a/front/src/routes/Login.tsx
+++ b/front/src/routes/Login.tsx
@@ -1,24 +1,42 @@
 import styles from '../styles/Login.module.css';
 import ftLogo from '../assets/42logo.svg';
-import { Link, useNavigate, useSubmit } from 'react-router-dom';
+import { Link, LoaderFunctionArgs, json, redirect } from 'react-router-dom';
 
 const LoginPage = () => {
-  const clickHandler = async () => {};
+  const redirectURL = process.env.REACT_APP_REDIRECT_URL;
 
   return (
-    <>
-      <div className={styles.login}>
+    <div className={styles.login}>
+      <img src={ftLogo} alt="42 icon" />
+      <h1>FT_Transcendence</h1>
+      <Link to={redirectURL as string}>
         <img src={ftLogo} alt="42 icon" />
-        <h1>FT_Transcendence</h1>
-        <button onClick={clickHandler}>
-          <img src={ftLogo} alt="42 icon" />
-          <span>Intra Login</span>
-        </button>
-        <Link to="https://api.intra.42.fr/oauth/authorize?client_id{preo}}&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fapi%2Fuser%2Foauth&response_type=code">
-          Login
-        </Link>
-      </div>
-    </>
+        <span>Intra Login</span>
+      </Link>
+    </div>
   );
 };
 export default LoginPage;
+
+export const getTokenLoader = async ({ request }: LoaderFunctionArgs) => {
+  const url = new URL(request.url);
+  const authCode = url.searchParams.get('code');
+
+  const res = await fetch('http://localhost:3001/api/auth', {
+    method: 'POST',
+    body: JSON.stringify({ code: authCode }),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!res.ok) {
+    throw json({ message: '로그인에 실패하였습니다' }, { status: 500 });
+  }
+
+  const data = await res.json();
+
+  console.log(data);
+  // 분기
+  return null;
+};

--- a/front/src/routes/Login.tsx
+++ b/front/src/routes/Login.tsx
@@ -1,12 +1,9 @@
 import styles from '../styles/Login.module.css';
 import ftLogo from '../assets/42logo.svg';
+import { Link, useNavigate, useSubmit } from 'react-router-dom';
 
 const LoginPage = () => {
-  const clickHandler = async () => {
-    const res = await fetch('http://localhost:3000/api/user/login');
-    const data = await res.json();
-    console.log(data);
-  };
+  const clickHandler = async () => {};
 
   return (
     <>
@@ -17,6 +14,9 @@ const LoginPage = () => {
           <img src={ftLogo} alt="42 icon" />
           <span>Intra Login</span>
         </button>
+        <Link to="https://api.intra.42.fr/oauth/authorize?client_id{preo}}&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fapi%2Fuser%2Foauth&response_type=code">
+          Login
+        </Link>
       </div>
     </>
   );

--- a/front/src/routes/Login.tsx
+++ b/front/src/routes/Login.tsx
@@ -3,7 +3,7 @@ import ftLogo from '../assets/42logo.svg';
 
 const LoginPage = () => {
   const clickHandler = async () => {
-    const res = await fetch('http://localhost:3000/login');
+    const res = await fetch('http://localhost:3000/api/user/login');
     const data = await res.json();
     console.log(data);
   };

--- a/front/src/routes/OAuth.tsx
+++ b/front/src/routes/OAuth.tsx
@@ -1,0 +1,68 @@
+import { useDispatch } from 'react-redux';
+import {
+  LoaderFunctionArgs,
+  useLoaderData,
+  json,
+  Navigate,
+  defer,
+  Await,
+} from 'react-router-dom';
+import { actions as authActions } from '../store/auth';
+import { Suspense } from 'react';
+
+type oAuthResponseData = {
+  jwtToken: string;
+  isSignUp: boolean;
+};
+
+type loaderData = {
+  oAuthData: oAuthResponseData;
+};
+
+const OAuth = () => {
+  const dispatch = useDispatch();
+  const data = useLoaderData() as loaderData;
+
+  return (
+    <Suspense fallback={<h1 style={{ textAlign: 'center' }}>...login...</h1>}>
+      <Await resolve={data.oAuthData}>
+        {(auth) => {
+          dispatch(authActions.setAuthToken(auth.jwtToken));
+          return (
+            <Navigate
+              to={auth.isSignUp ? '/' : '/setting-profile'}
+              replace={true}
+            />
+          );
+        }}
+      </Await>
+    </Suspense>
+  );
+};
+export default OAuth;
+
+const requestOAuth = async (request: Request) => {
+  const url = new URL(request.url);
+  const authCode = url.searchParams.get('code');
+
+  const res = await fetch('http://localhost:3001/api/auth', {
+    method: 'POST',
+    body: JSON.stringify({ code: authCode }),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!res.ok) {
+    throw json({ message: '로그인에 실패하였습니다' }, { status: 500 });
+  }
+
+  const data = await res.json();
+  return data;
+};
+
+export const loader = ({ request }: LoaderFunctionArgs) => {
+  return defer({
+    oAuthData: requestOAuth(request),
+  });
+};

--- a/front/src/routes/ProtectedRouter.tsx
+++ b/front/src/routes/ProtectedRouter.tsx
@@ -1,0 +1,14 @@
+import { useSelector } from 'react-redux';
+import { RootStoreType } from '../store';
+import { Navigate, Outlet } from 'react-router-dom';
+
+const ProtectedRouter = () => {
+  const auth = useSelector((state: RootStoreType) => state.auth);
+
+  if (!auth.token) {
+    return <Navigate to="/login" />;
+  } else {
+    return <Outlet />;
+  }
+};
+export default ProtectedRouter;

--- a/front/src/routes/RootLayout.tsx
+++ b/front/src/routes/RootLayout.tsx
@@ -1,4 +1,3 @@
-import { Fragment } from 'react';
 import { Outlet } from 'react-router-dom';
 
 import Navigation from '../components/Navigation/Navigation';

--- a/front/src/routes/SettingProfile.tsx
+++ b/front/src/routes/SettingProfile.tsx
@@ -30,6 +30,7 @@ const action = async ({ request }: ActionFunctionArgs) => {
   if (name.length < 4 || name.length > 8) {
     return json({ errorMessage: '닉네임 길이는 4~8자 입니다.' });
   }
+
   store.dispatch(authActions.setUserID(name));
   return redirect('/');
 };

--- a/front/src/routes/SettingProfile.tsx
+++ b/front/src/routes/SettingProfile.tsx
@@ -1,5 +1,7 @@
-import { json, redirect } from 'react-router-dom';
+import { ActionFunctionArgs, json, redirect } from 'react-router-dom';
 import SettingProfileForm from '../components/SettingProfile/SettingProfileForm';
+import store from '../store';
+import { actions as authActions } from '../store/auth';
 
 const SettingProfilePage = () => {
   return (
@@ -10,11 +12,7 @@ const SettingProfilePage = () => {
   );
 };
 
-type ActionParams = {
-  request: Request;
-};
-
-const action = async ({ request }: ActionParams) => {
+const action = async ({ request }: ActionFunctionArgs) => {
   const data = await request.formData();
 
   const avatarFile = data.get('avatar') as File;
@@ -32,7 +30,7 @@ const action = async ({ request }: ActionParams) => {
   if (name.length < 4 || name.length > 8) {
     return json({ errorMessage: '닉네임 길이는 4~8자 입니다.' });
   }
-
+  store.dispatch(authActions.setUserID(name));
   return redirect('/');
 };
 

--- a/front/src/routes/TwoFactorAuth.tsx
+++ b/front/src/routes/TwoFactorAuth.tsx
@@ -5,6 +5,7 @@ const TwoFactorAuthPage = () => {
   const clickHandler = () => {
     navigate('/setting-profile');
   };
+
   return (
     <main>
       <h1>2차 인증 페이지</h1>

--- a/front/src/routes/index.tsx
+++ b/front/src/routes/index.tsx
@@ -8,88 +8,52 @@ import DashboardPage from './Dashboard';
 import ProfilePage from './Profile';
 import FriendsPage from './Friends';
 import ChannelsPage from './Channels';
-import LoginPage, { getTokenLoader } from './Login';
+import LoginPage from './Login';
 import SettingProfilePage, {
   action as settingProfileAction,
 } from './SettingProfile';
 import GamePage from './Game';
 import TwoFactorAuthPage from './TwoFactorAuth';
 import ChattingPage from './Chatting';
-import store from '../store';
+import OAuth, { loader as oAuthLoader } from './OAuth';
+import ProtectedRouter from './ProtectedRouter';
 
 const router = createBrowserRouter([
   {
     errorElement: <ErrorPage />,
-    loader: () => {
-      if (store.getState().auth.token === '') return redirect('/login');
-      return null;
-    },
+    element: <ProtectedRouter />,
     children: [
       {
         path: '/',
         element: <RootLayout />,
         children: [
           {
-            index: true,
+            path: '/',
             element: <MainPage />,
-            // 임시 액션 딜레이
             action: async () => {
               await new Promise((res) => setTimeout(res, 1000));
               return redirect('/game/1');
             },
           },
           {
-            path: '/dashboard',
-            children: [
-              { index: true, element: <DashboardPage /> },
-              { path: ':userID', element: <DashboardPage /> },
-            ],
+            path: '/dashboard/:userID',
+            element: <DashboardPage />,
           },
           {
             path: '/channels',
             element: <ChannelsPage />,
-            action: async ({ request }) => {
-              const data = await request.formData();
-              console.log(data.get('room-type'));
-              console.log(data.get('room-name'));
-              console.log(data.get('room-password'));
-              return null;
-            },
           },
           {
             path: '/chatting/:mode/:chatID',
             element: <ChattingPage />,
-            action: async ({ request }) => {
-              const data = await request.formData();
-              if (request.method === 'POST') {
-                console.log(data.get('name'));
-              }
-              if (request.method === 'PATCH') {
-                console.log(data.get('room-type'));
-                console.log(data.get('room-name'));
-                console.log(data.get('room-password'));
-              }
-              if (request.method === 'DELETE') {
-                console.log('channel delete');
-              }
-              return null;
-            },
           },
           {
             path: '/friends',
             element: <FriendsPage />,
-            action: async ({ request }) => {
-              const data = await request.formData();
-              console.log(data.get('name'));
-              return null;
-            },
           },
           {
-            path: '/profile',
-            children: [
-              { index: true, element: <ProfilePage /> },
-              { path: ':userID', element: <ProfilePage /> },
-            ],
+            path: '/profile/:userID',
+            element: <ProfilePage />,
           },
         ],
       },
@@ -115,17 +79,12 @@ const router = createBrowserRouter([
   },
   {
     path: '/login',
-    errorElement: <ErrorPage />,
-    children: [
-      { index: true, element: <LoginPage /> },
-      { path: 'oauth', loader: getTokenLoader, element: <></> },
-    ],
+    element: <LoginPage />,
   },
   {
-    path: '/logout',
-    action: () => {
-      return redirect('/login');
-    },
+    path: '/oauth',
+    element: <OAuth />,
+    loader: oAuthLoader,
   },
 ]);
 

--- a/front/src/routes/index.tsx
+++ b/front/src/routes/index.tsx
@@ -8,28 +8,22 @@ import DashboardPage from './Dashboard';
 import ProfilePage from './Profile';
 import FriendsPage from './Friends';
 import ChannelsPage from './Channels';
-import LoginPage from './Login';
+import LoginPage, { getTokenLoader } from './Login';
 import SettingProfilePage, {
   action as settingProfileAction,
 } from './SettingProfile';
 import GamePage from './Game';
 import TwoFactorAuthPage from './TwoFactorAuth';
 import ChattingPage from './Chatting';
-
-const routerLoader = async ({ request }: { request: Request }) => {
-  console.log('루트 loader');
-  return 1;
-};
-const routerAction = async ({ request }: { request: Request }) => {
-  console.log('루트 action');
-  return 1;
-};
+import store from '../store';
 
 const router = createBrowserRouter([
   {
     errorElement: <ErrorPage />,
-    loader: routerLoader,
-    action: routerAction,
+    loader: () => {
+      if (store.getState().auth.token === '') return redirect('/login');
+      return null;
+    },
     children: [
       {
         path: '/',
@@ -41,7 +35,6 @@ const router = createBrowserRouter([
             // 임시 액션 딜레이
             action: async () => {
               await new Promise((res) => setTimeout(res, 1000));
-
               return redirect('/game/1');
             },
           },
@@ -122,12 +115,15 @@ const router = createBrowserRouter([
   },
   {
     path: '/login',
-    element: <LoginPage />,
+    errorElement: <ErrorPage />,
+    children: [
+      { index: true, element: <LoginPage /> },
+      { path: 'oauth', loader: getTokenLoader, element: <></> },
+    ],
   },
   {
     path: '/logout',
     action: () => {
-      console.log('logout!');
       return redirect('/login');
     },
   },

--- a/front/src/store/ReduxProvider.tsx
+++ b/front/src/store/ReduxProvider.tsx
@@ -1,4 +1,5 @@
-import store from '.';
+import { PersistGate } from 'redux-persist/integration/react';
+import store, { persistor } from '.';
 import { Provider } from 'react-redux';
 
 type Props = {
@@ -6,6 +7,13 @@ type Props = {
 };
 
 const ReduxProvider = ({ children }: Props) => {
-  return <Provider store={store}>{children}</Provider>;
+  return (
+    <Provider store={store}>
+      <PersistGate loading={null} persistor={persistor}>
+        {children}
+      </PersistGate>
+    </Provider>
+  );
 };
+
 export default ReduxProvider;

--- a/front/src/store/auth.ts
+++ b/front/src/store/auth.ts
@@ -1,0 +1,33 @@
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
+
+type AuthState = {
+  token: string;
+  userID: string;
+};
+
+const initialState: AuthState = {
+  token: '',
+  userID: '',
+};
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    setAuthToken: (state, action: PayloadAction<string>) => {
+      state.token = action.payload;
+    },
+
+    setUserID: (state, action: PayloadAction<string>) => {
+      state.userID = action.payload;
+    },
+
+    logout: (state) => {
+      state = initialState;
+    },
+  },
+});
+
+export type { AuthState };
+export const actions = authSlice.actions;
+export default authSlice;

--- a/front/src/store/auth.ts
+++ b/front/src/store/auth.ts
@@ -23,7 +23,8 @@ const authSlice = createSlice({
     },
 
     logout: (state) => {
-      state = initialState;
+      state.token = '';
+      state.userID = '';
     },
   },
 });

--- a/front/src/store/index.ts
+++ b/front/src/store/index.ts
@@ -2,14 +2,31 @@ import { combineReducers, configureStore } from '@reduxjs/toolkit';
 
 import modalSlice from './modal';
 import authSlice from './auth';
+import { persistStore, persistReducer } from 'redux-persist';
+import storage from 'redux-persist/lib/storage';
 
 const rootReducer = combineReducers({
   modal: modalSlice.reducer,
   auth: authSlice.reducer,
 });
+
+const persistConfig = {
+  key: 'root',
+  version: 1,
+  storage,
+  whitelist: ['auth'],
+};
+
+const persistedReducer = persistReducer(persistConfig, rootReducer);
+
 const store = configureStore({
-  reducer: rootReducer,
+  reducer: persistedReducer,
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({
+      serializableCheck: false,
+    }),
 });
 
+export const persistor = persistStore(store);
 export type RootStoreType = ReturnType<typeof store.getState>;
 export default store;

--- a/front/src/store/index.ts
+++ b/front/src/store/index.ts
@@ -1,11 +1,14 @@
-import { configureStore } from '@reduxjs/toolkit';
+import { combineReducers, configureStore } from '@reduxjs/toolkit';
 
 import modalSlice from './modal';
+import authSlice from './auth';
 
+const rootReducer = combineReducers({
+  modal: modalSlice.reducer,
+  auth: authSlice.reducer,
+});
 const store = configureStore({
-  reducer: {
-    modal: modalSlice.reducer,
-  },
+  reducer: rootReducer,
 });
 
 export type RootStoreType = ReturnType<typeof store.getState>;

--- a/front/src/styles/Login.module.css
+++ b/front/src/styles/Login.module.css
@@ -17,7 +17,7 @@
   color: #777777;
 }
 
-.login button {
+.login a {
   margin-top: 32px;
   width: 240px;
 
@@ -31,11 +31,13 @@
   align-items: center;
 }
 
-.login button img {
+.login a img {
   width: 24px;
 }
-.login button span {
+
+.login a span {
   color: white;
   flex: 1;
   font-size: 24px;
+  text-align: center;
 }


### PR DESCRIPTION
## 작업 내용
- front OAuth 로그인 구현 완료
- 전역 상태 구현 완료
  - redux-persist 로 새로고침에 persist (새탭 포함)
- ProtectedRouter 구현하여 라우팅 보호

## 추가 작업 (리팩토링)
- 불필요 Action 모두 지움

## 테스트 및 주요 사항
- backend와 통신이 가능해야 하기 때문에 backend를 추후 merge후 테스트해야 함
  - backend는 각종 설정 파일을 세팅할 필요 있음
- **front/src/route/index.tsx 에서 19번줄, 24번줄에 있는 `ProtectedRouter`를 주석하여 로그인 기능을 꺼놓고 개발 진행**